### PR TITLE
Add ability to reactivate cancelled pins for the current members

### DIFF
--- a/app/Controller/MembersController.php
+++ b/app/Controller/MembersController.php
@@ -70,6 +70,7 @@ class MembersController extends AppController {
 			case 'uploadCsv':
 			case 'uploadTsb':
 			case 'emailMembersWithStatus':
+            case 'resetPinToEnroll':
 				return $memberIsMembershipAdmin;
 
 			case 'sendProspectiveMemberReminder':
@@ -1048,6 +1049,23 @@ class MembersController extends AppController {
 		return $memberList;
 	}
 
+/** 
+ * Reset Pin To allow RFID Enroll
+ * 
+ * @param int $memberId 
+ *
+ */
+    public function resetPinToEnroll($memberId) {
+        // TODO: fix this, either use Pin model directly or add wrap helper to Member
+        if ($this->Member->Pin->resetPinToEnrollForMember($memberId)) {
+            $this->Session->setFlash('Pin has been reactivated');
+        } else {
+            $this->Session->setFlash('Failed to set pin to Enroll');
+        }
+        
+        return $this->redirect(array('action' => 'view', $memberId));
+    }
+
 /**
  * Get an array of possible actions for a member
  *
@@ -1170,7 +1188,20 @@ class MembersController extends AppController {
 						),
 					)
 				);
-
+                
+                // TODO: fix this, either use Pin model directly or add wrap helper to Member
+                if ($this->Member->Pin->getPinStateForMember($memberId) == Pin::STATE_CANCELLED) {
+                    array_push($actions,
+                        array(
+                            'title' => 'Reactivate Pin',
+                            'controller' => 'members',
+                            'action' => 'resetPinToEnroll',
+                            'params' => array(
+                                $memberId,
+                            ),
+                        )
+                    );
+                }
 			break;
 
 			case Status::EX_MEMBER:

--- a/app/Controller/RfidtagsController.php
+++ b/app/Controller/RfidtagsController.php
@@ -84,7 +84,6 @@ class RfidTagsController extends AppController {
  * @param int|null $memberId The id fo the member to view; null grabs the currently logged-in user id instead
  */
 	public function view($memberId = null) {
-		//$this->loadModel('Transactions');
 
 		if ($memberId == null) {
 			$memberId = $this->_getLoggedInMemberId();
@@ -104,7 +103,6 @@ class RfidTagsController extends AppController {
  * @param int|null $rfidSerial The serial number of the card to edit
  */
 	public function edit($rfidSerial = null) {
-		//$this->loadModel('Transactions');
 
 		$this->set('states', $this->RfidTag->statusStrings);
 

--- a/app/Controller/RfidtagsController.php
+++ b/app/Controller/RfidtagsController.php
@@ -13,16 +13,6 @@
  * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
-// App::uses('AppController', 'Controller');
-// App::uses('HmsAuthenticate', 'Controller/Component/Auth');
- //App::uses('MembersController', 'Controller');
-// App::uses('ForgotPassword', 'Model');
-// App::uses('CakeEmail', 'Network/Email');
-// App::uses('PhpReader', 'Configure');
-// Configure::config('default', new PhpReader());
-// Configure::load('hms', 'default');
-
-
 /**
  * Controller to handle Member functionality, allows members to be viewed,
  * edited, and registered.

--- a/app/Model/Member.php
+++ b/app/Model/Member.php
@@ -483,11 +483,11 @@ class Member extends AppModel {
 				[n] =>
 					[id] => pin id
 					[pin] => pin number
-					[statee] => pin state (see constance defined in Pin.php)
+					[state] => pin state (see constance defined in Pin.php)
             [rfidtag] =>
                 [n] =>
                     [serial] => rfid_serial
-                    [state] => state (see constance deined in RfidTag.php
+                    [state] => state (see constance deined in RfidTag.php)
                     [last_used] => last_used
                     [name] => friendly_name
 			[paymentRef] => member payment ref

--- a/app/Model/Pin.php
+++ b/app/Model/Pin.php
@@ -40,6 +40,15 @@ class Pin extends AppModel {
  */
 	const STATE_ENROLL = 40;
 
+/** 
+ * String representation of states for display
+ */
+    public $statusStrings = array(
+                                  10 => 'Active',
+                                  20 => 'Expired',
+                                  30 => 'Calcelled',
+                                  40 => 'Enroll',
+                                  );
 /**
  * Specify the table to use.
  * @var string
@@ -147,4 +156,52 @@ class Pin extends AppModel {
 		return false;
 	}
 
+/**
+ * Reset pin to enroll state
+ *
+ * @param int $memberId The id of the member pin to change
+ * @return bool pass or fail
+ */
+    public function resetPinToEnrollForMember($memberId) {
+        if (is_numeric($memberId) && $memberId > 0) {
+            $findOptions = array(
+                'conditions' => array(
+                    'Pin.member_id' => $memberId,
+                ),
+                'fields' => array('Pin.*'),
+            );
+            // should only get one pin back anyway
+            $pinRecord = $this->find('first', $findOptions);
+
+            if ((int)$pinRecord['Pin']['state'] == Pin::STATE_CANCELLED) {
+                $pinRecord['Pin']['state'] = Pin::STATE_ENROLL;
+                return ($this->save($pinRecord) != false);
+            } else {
+                return false;
+            }
+        }
+        return false;
+    }
+    
+/**
+ * Get pin state for memberId
+ *
+ * @param int $memberId The id of the member
+ * @return mixed False if no pin exists, pin state other wise
+ */
+    public function getPinStateForMember($memberId) {
+        if (is_numeric($memberId) && $memberId > 0) {
+                        $findOptions = array(
+                'conditions' => array(
+                    'Pin.member_id' => $memberId,
+                ),
+                'fields' => array('Pin.state'),
+            );
+            // should only get one pin back anyway
+            $pinRecord = $this->find('first', $findOptions);
+            
+            return $pinRecord['Pin']['state'];
+        }
+        return false;
+    }
 }

--- a/app/Model/RfidTag.php
+++ b/app/Model/RfidTag.php
@@ -30,13 +30,19 @@ class RfidTag extends AppModel {
  */
 	const STATE_EXPIRED = 20;
 
+/**
+ * RfidTag has been lost and can no longer be used for entry.
+ */
 	const STATE_LOST = 30;
 
-public $statusStrings = array(
-	10 => 'Active',
-	20 => 'Expired',
-	30 => 'Lost',
-	);
+/**
+ * String representation of states for display
+ */
+    public $statusStrings = array(
+                                  10 => 'Active',
+                                  20 => 'Expired',
+                                  30 => 'Lost',
+                                  );
 
 /**
  * Specify the table to use.
@@ -129,14 +135,20 @@ public $statusStrings = array(
 		return $info;
 	}
 
-
-public function formatRfidTagList($tagsList, $removeNullEntries) {
-	$formatted = array();
-	foreach($tagsList as $tag) {
-		array_push($formatted, $this->formatDetails($tag, $removeNullEntries));
-	}
-	return $formatted;
-}
+/**
+ * Format an array of tags
+ * 
+ * @param array $tagsList The array of tags.
+ * @param bool $removeNullEntries If true then entries that have a value of null, false or an empty array won't exist in the final array.
+ * @return array A list of tags or query to report a list of tags
+ */
+    public function formatRfidTagList($tagsList, $removeNullEntries) {
+        $formatted = array();
+        foreach($tagsList as $tag) {
+            array_push($formatted, $this->formatDetails($tag, $removeNullEntries));
+        }
+        return $formatted;
+    }
 
 /**
  * Flatten tag details array

--- a/app/Test/Case/Controller/MembersControllerTest.php
+++ b/app/Test/Case/Controller/MembersControllerTest.php
@@ -1909,13 +1909,14 @@
 
 			$this->_constructMailingList();
 
-			$this->controller->Nav->expects($this->exactly(6))->method('add');
+			$this->controller->Nav->expects($this->exactly(7))->method('add');
 			$this->controller->Nav->expects($this->at(0))->method('add')->with('View Email History', 'emailRecords', 'view', array(4));
 			$this->controller->Nav->expects($this->at(1))->method('add')->with('Edit', 'members', 'edit', array(4));
 			$this->controller->Nav->expects($this->at(2))->method('add')->with('Change Password', 'members', 'changePassword', array(4));
 			$this->controller->Nav->expects($this->at(3))->method('add')->with('Revoke Membership', 'members', 'revokeMembership', array(4));
 			$this->controller->Nav->expects($this->at(4))->method('add')->with('Send SO Details Reminder', 'members', 'sendSoDetailsReminder', array(4));
 			$this->controller->Nav->expects($this->at(5))->method('add')->with('Resend Welcome Email', 'members', 'sendMembershipCompleteMail', array(4));
+            $this->controller->Nav->expects($this->at(6))->method('add')->with('Reactivate Pin', 'members', 'resetPinToEnroll', array(4));
 
 			// Should not redirect, and should populate
 			$this->testAction('members/view/4');
@@ -2016,13 +2017,15 @@
 
 			$this->_constructMailingList();
 
-			$this->controller->Nav->expects($this->exactly(6))->method('add');
+			$this->controller->Nav->expects($this->exactly(7))->method('add');
 			$this->controller->Nav->expects($this->at(0))->method('add')->with('View Email History', 'emailRecords', 'view', array(3));
 			$this->controller->Nav->expects($this->at(1))->method('add')->with('Edit', 'members', 'edit', array(3));
 			$this->controller->Nav->expects($this->at(2))->method('add')->with('Change Password', 'members', 'changePassword', array(3));
 			$this->controller->Nav->expects($this->at(3))->method('add')->with('Revoke Membership', 'members', 'revokeMembership', array(3));
 			$this->controller->Nav->expects($this->at(4))->method('add')->with('Send SO Details Reminder', 'members', 'sendSoDetailsReminder', array(3));
 			$this->controller->Nav->expects($this->at(5))->method('add')->with('Resend Welcome Email', 'members', 'sendMembershipCompleteMail', array(3));
+            $this->controller->Nav->expects($this->at(6))->method('add')->with('Reactivate Pin', 'members', 'resetPinToEnroll', array(3));
+
 
 			// Should not redirect, and should populate
  				$this->testAction('members/view/3');
@@ -2106,13 +2109,14 @@
 
 			$this->_constructMailingList();
 
-			$this->controller->Nav->expects($this->exactly(6))->method('add');
+			$this->controller->Nav->expects($this->exactly(7))->method('add');
 			$this->controller->Nav->expects($this->at(0))->method('add')->with('View Email History', 'emailRecords', 'view', array(4));
 			$this->controller->Nav->expects($this->at(1))->method('add')->with('Edit', 'members', 'edit', array(4));
 			$this->controller->Nav->expects($this->at(2))->method('add')->with('Change Password', 'members', 'changePassword', array(4));
 			$this->controller->Nav->expects($this->at(3))->method('add')->with('Revoke Membership', 'members', 'revokeMembership', array(4));
 			$this->controller->Nav->expects($this->at(4))->method('add')->with('Send SO Details Reminder', 'members', 'sendSoDetailsReminder', array(4));
 			$this->controller->Nav->expects($this->at(5))->method('add')->with('Resend Welcome Email', 'members', 'sendMembershipCompleteMail', array(4));
+            $this->controller->Nav->expects($this->at(6))->method('add')->with('Reactivate Pin', 'members', 'resetPinToEnroll', array(4));
 
 			// Should not redirect, and should populate
 			$this->testAction('members/view/4');
@@ -2213,12 +2217,13 @@
 
 			$this->_constructMailingList();
 
-			$this->controller->Nav->expects($this->exactly(5))->method('add');
+			$this->controller->Nav->expects($this->exactly(6))->method('add');
 			$this->controller->Nav->expects($this->at(0))->method('add')->with('Edit', 'members', 'edit', array(3));
 			$this->controller->Nav->expects($this->at(1))->method('add')->with('Change Password', 'members', 'changePassword', array(3));
 			$this->controller->Nav->expects($this->at(2))->method('add')->with('Revoke Membership', 'members', 'revokeMembership', array(3));
 			$this->controller->Nav->expects($this->at(3))->method('add')->with('Send SO Details Reminder', 'members', 'sendSoDetailsReminder', array(3));
 			$this->controller->Nav->expects($this->at(4))->method('add')->with('Resend Welcome Email', 'members', 'sendMembershipCompleteMail', array(3));
+            $this->controller->Nav->expects($this->at(5))->method('add')->with('Reactivate Pin', 'members', 'resetPinToEnroll', array(3));
 
 			// Should not redirect, and should populate
 			$this->testAction('members/view/3');


### PR DESCRIPTION
Button only shows if Pin state is cancelled
Membership Admin team have access, not Membership Team
Needs CSS fixing as we can now display to many nav buttons across the bottom

Once merged and released membership team will no longer need to go near nh-web :)